### PR TITLE
refactor: go memory management

### DIFF
--- a/cgo/block_client.go
+++ b/cgo/block_client.go
@@ -20,7 +20,7 @@ func NewBlockClient(depsRef C.go_ref, cErr **C.char) C.go_ref {
 	// TODO_CONSIDERATION: Could support a version of methods which receive a go context, created elsewhere..
 	ctx := context.Background()
 
-	deps, err := GetGoMem[depinject.Config](GoRef(depsRef))
+	deps, err := GetGoMem[depinject.Config](depsRef)
 	if err != nil {
 		*cErr = C.CString(err.Error())
 		return C.go_ref(NilGoRef)
@@ -32,5 +32,5 @@ func NewBlockClient(depsRef C.go_ref, cErr **C.char) C.go_ref {
 		return C.go_ref(NilGoRef)
 	}
 
-	return C.go_ref(SetGoMem(blockClient))
+	return SetGoMem(blockClient)
 }

--- a/cgo/block_query_client.go
+++ b/cgo/block_query_client.go
@@ -23,7 +23,7 @@ func NewBlockQueryClient(cometWebsocketURL *C.char, cErr **C.char) C.go_ref {
 		return C.go_ref(NilGoRef)
 	}
 
-	return C.go_ref(SetGoMem(blockQueryClient))
+	return SetGoMem(blockQueryClient)
 }
 
 //export BlockQuery_ClientBlock
@@ -38,7 +38,7 @@ func BlockQuery_ClientBlock(clientRef C.go_ref, cHeight *C.int64_t, cErr **C.cha
 	ctx := context.Background()
 
 	blockQueryClient, err :=
-		GetGoMem[client.BlockQueryClient](GoRef(clientRef))
+		GetGoMem[client.BlockQueryClient](clientRef)
 	if err != nil {
 		*cErr = C.CString(err.Error())
 		return C.go_ref(NilGoRef)
@@ -51,5 +51,5 @@ func BlockQuery_ClientBlock(clientRef C.go_ref, cHeight *C.int64_t, cErr **C.cha
 	}
 
 	// TODO_IN_THIS_COMMIT: return C-native struct.
-	return C.go_ref(SetGoMem(resultBlock))
+	return SetGoMem(resultBlock)
 }

--- a/cgo/depinject.go
+++ b/cgo/depinject.go
@@ -12,14 +12,14 @@ import (
 )
 
 //export Supply
-func Supply(goRef GoRef, cErr **C.char) C.go_ref {
+func Supply(goRef C.go_ref, cErr **C.char) C.go_ref {
 	toSupply, err := GetGoMem[any](goRef)
 	if err != nil {
 		*cErr = C.CString(err.Error())
 		return 0
 	}
 
-	return C.go_ref(SetGoMem(depinject.Supply(toSupply)))
+	return SetGoMem(depinject.Supply(toSupply))
 }
 
 //export SupplyMany
@@ -36,7 +36,7 @@ func SupplyMany(goRefs *C.go_ref, numGoRefs C.int, cErr **C.char) C.go_ref {
 
 	var toSupply []any
 	for _, ref := range refs {
-		valueToSupply, err := GetGoMem[any](GoRef(ref))
+		valueToSupply, err := GetGoMem[any](ref)
 		if err != nil {
 			*cErr = C.CString(err.Error())
 			//*cErr = C.CString(fmt.Sprintf("%+v", err))
@@ -46,7 +46,7 @@ func SupplyMany(goRefs *C.go_ref, numGoRefs C.int, cErr **C.char) C.go_ref {
 		toSupply = append(toSupply, valueToSupply)
 	}
 
-	return C.go_ref(SetGoMem(depinject.Supply(toSupply...)))
+	return SetGoMem(depinject.Supply(toSupply...))
 }
 
 //export Config
@@ -55,7 +55,7 @@ func Config(goRefs *C.go_ref, numGoRefs C.int, cErr **C.char) C.go_ref {
 
 	var configs []depinject.Config
 	for _, ref := range refs {
-		cfg, err := GetGoMem[depinject.Config](GoRef(ref))
+		cfg, err := GetGoMem[depinject.Config](ref)
 		if err != nil {
 			*cErr = C.CString(err.Error())
 			return 0
@@ -64,5 +64,5 @@ func Config(goRefs *C.go_ref, numGoRefs C.int, cErr **C.char) C.go_ref {
 		configs = append(configs, cfg)
 	}
 
-	return C.go_ref(SetGoMem(depinject.Configs(configs...)))
+	return SetGoMem(depinject.Configs(configs...))
 }

--- a/cgo/events_query_client.go
+++ b/cgo/events_query_client.go
@@ -21,7 +21,7 @@ func NewEventsQueryClient(cometWebsocketURLCString *C.char) C.go_ref {
 	cometWebsocketURL := C.GoString(cometWebsocketURLCString)
 	eventsQueryClient := events.NewEventsQueryClient(cometWebsocketURL)
 
-	return C.go_ref(SetGoMem(eventsQueryClient))
+	return SetGoMem(eventsQueryClient)
 }
 
 //export EventsQueryClientEventsBytes
@@ -30,7 +30,7 @@ func EventsQueryClientEventsBytes(clientRef C.go_ref, query *C.char, cErr **C.ch
 	ctx := context.Background()
 
 	eventsQueryClient, err :=
-		GetGoMem[client.EventsQueryClient](GoRef(clientRef))
+		GetGoMem[client.EventsQueryClient](clientRef)
 	if err != nil {
 		*cErr = C.CString(err.Error())
 		return C.go_ref(NilGoRef)
@@ -42,5 +42,5 @@ func EventsQueryClientEventsBytes(clientRef C.go_ref, query *C.char, cErr **C.ch
 		return C.go_ref(NilGoRef)
 	}
 
-	return C.go_ref(SetGoMem(eventsBytesObs))
+	return SetGoMem(eventsBytesObs)
 }

--- a/cgo/memory.go
+++ b/cgo/memory.go
@@ -5,31 +5,52 @@ package main
 #include <memory.h>
 */
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
 
 const (
-	// TODO_IN_THIS_COMMIT: godoc...
+	// NilGoRef is a Go reference which is used to indicate a nil/NULL reference.
 	NilGoRef = GoRef(-1)
-	// TODO_IN_THIS_COMMIT: godoc...
-	ZeroGoRef = GoRef(0)
 )
 
 var (
-	goMemoryMap  = map[GoRef]any{}
-	nextGoMemRef = GoRef(0)
+	// goMemoryMapMu is a mutex used to protect goMemoryMap during concurrent usage.
+	goMemoryMapMu sync.RWMutex
+	// goMemoryMap is a map of Go references to values. The map is used to store
+	// values which are allocated in Go and which need to be passed back to C.
+	goMemoryMap = map[GoRef]any{}
+	// nextGoMemRef is the next Go reference to be allocated. It is incremented
+	// each time a new reference is allocated. IT is an atomic int64 to guarantee
+	// refernce uniqueness in the presence of concurrent usage.
+	nextGoMemRef atomic.Int64
 )
 
+// GoRef is a type alias for a monotonically increasing integer which is used as
+// a key ("reference") to a value stored in the goMemoryMap.
 type GoRef int64
 
-// TODO_IN_THIS_COMMIT: godoc...
+// SetGoMem stores the given value in the goMemoryMap, protecting it from garbage
+// collection, and returns the "reference" which is that value's map key. Reference
+// keys are monotically increasing integers, starting at 1. -1 and/or 0 MAY be used
+// to indicate a nil/NULL reference.
 func SetGoMem(value any) C.go_ref {
-	nextGoMemRef++
-	goMemoryMap[nextGoMemRef] = value
-	return C.go_ref(nextGoMemRef)
+	nextRef := GoRef(nextGoMemRef.Add(1))
+
+	goMemoryMapMu.Lock()
+	defer goMemoryMapMu.Unlock()
+
+	goMemoryMap[nextRef] = value
+	return C.go_ref(nextRef)
 }
 
-// TODO_IN_THIS_COMMIT: godoc...
+// GetGoMem returns the value associated with the given Go reference.
 func GetGoMem[T any](ref C.go_ref) (T, error) {
+	goMemoryMapMu.RLock()
+	defer goMemoryMapMu.RUnlock()
+
 	value, ok := goMemoryMap[GoRef(ref)]
 	if !ok {
 		return *new(T), fmt.Errorf("go memory reference not found: %d", ref)
@@ -43,9 +64,12 @@ func GetGoMem[T any](ref C.go_ref) (T, error) {
 	return valueT, nil
 }
 
-// TODO_IN_THIS_COMMIT: godoc...
+// FreeGoMem frees the go-allocated memory associated with the given Go reference.
 //
 //export FreeGoMem
 func FreeGoMem(ref C.go_ref) {
+	goMemoryMapMu.Lock()
+	defer goMemoryMapMu.Unlock()
+
 	delete(goMemoryMap, GoRef(ref))
 }

--- a/cgo/memory.go
+++ b/cgo/memory.go
@@ -22,15 +22,15 @@ var (
 type GoRef int64
 
 // TODO_IN_THIS_COMMIT: godoc...
-func SetGoMem(value any) GoRef {
+func SetGoMem(value any) C.go_ref {
 	nextGoMemRef++
 	goMemoryMap[nextGoMemRef] = value
-	return nextGoMemRef
+	return C.go_ref(nextGoMemRef)
 }
 
 // TODO_IN_THIS_COMMIT: godoc...
-func GetGoMem[T any](ref GoRef) (T, error) {
-	value, ok := goMemoryMap[ref]
+func GetGoMem[T any](ref C.go_ref) (T, error) {
+	value, ok := goMemoryMap[GoRef(ref)]
 	if !ok {
 		return *new(T), fmt.Errorf("go memory reference not found: %d", ref)
 	}
@@ -46,6 +46,6 @@ func GetGoMem[T any](ref GoRef) (T, error) {
 // TODO_IN_THIS_COMMIT: godoc...
 //
 //export FreeGoMem
-func FreeGoMem(ref GoRef) {
-	delete(goMemoryMap, ref)
+func FreeGoMem(ref C.go_ref) {
+	delete(goMemoryMap, GoRef(ref))
 }

--- a/cgo/tx_client.go
+++ b/cgo/tx_client.go
@@ -41,7 +41,7 @@ func NewTxClient(depsRef C.go_ref, signingKeyName *C.char, cErr **C.char) C.go_r
 	// TODO_CONSIDERATION: Could support a version of methods which receive a go context, created elsewhere..
 	ctx := context.Background()
 
-	deps, err := GetGoMem[depinject.Config](GoRef(depsRef))
+	deps, err := GetGoMem[depinject.Config](depsRef)
 	if err != nil {
 		*cErr = C.CString(err.Error())
 		return C.go_ref(NilGoRef)
@@ -54,12 +54,12 @@ func NewTxClient(depsRef C.go_ref, signingKeyName *C.char, cErr **C.char) C.go_r
 		return C.go_ref(NilGoRef)
 	}
 
-	return C.go_ref(SetGoMem(txClient))
+	return SetGoMem(txClient)
 }
 
 //export WithSigningKeyName
 func WithSigningKeyName(keyName *C.char) C.go_ref {
-	return C.go_ref(SetGoMem(tx.WithSigningKeyName(C.GoString(keyName))))
+	return SetGoMem(tx.WithSigningKeyName(C.GoString(keyName)))
 }
 
 // TODO_IN_THIS_COMMIT: godoc...
@@ -72,7 +72,7 @@ func TxClient_SignAndBroadcast(
 ) C.go_ref {
 	goCtx := context.Background()
 
-	txClient, err := GetGoMem[client.TxClient](GoRef(txClientRef))
+	txClient, err := GetGoMem[client.TxClient](txClientRef)
 	if err != nil {
 		err = fmt.Errorf("getting tx client ref: %s", err)
 		C.bridge_error(op, C.CString(err.Error()))
@@ -113,7 +113,7 @@ func TxClient_SignAndBroadcast(
 		}
 	}()
 
-	return C.go_ref(SetGoMem(errCh))
+	return SetGoMem(errCh)
 }
 
 // TODO_IN_THIS_COMMIT: godoc...
@@ -126,7 +126,7 @@ func TxClient_SignAndBroadcastMany(
 ) C.go_ref {
 	goCtx := context.Background()
 
-	txClient, err := GetGoMem[client.TxClient](GoRef(txClientRef))
+	txClient, err := GetGoMem[client.TxClient](txClientRef)
 	if err != nil {
 		err = fmt.Errorf("getting tx client ref: %s", err)
 		C.bridge_error(op, C.CString(err.Error()))
@@ -160,5 +160,5 @@ func TxClient_SignAndBroadcastMany(
 		}
 	}()
 
-	return C.go_ref(SetGoMem(errCh))
+	return SetGoMem(errCh)
 }

--- a/cgo/tx_client.go
+++ b/cgo/tx_client.go
@@ -76,7 +76,7 @@ func TxClient_SignAndBroadcast(
 	if err != nil {
 		err = fmt.Errorf("getting tx client ref: %s", err)
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	typeUrl := string(C.GoBytes(unsafe.Pointer(serializedProto.type_url), C.int(serializedProto.type_url_length)))
@@ -90,19 +90,19 @@ func TxClient_SignAndBroadcast(
 	msg, err := interfaceRegistry.Resolve(typeUrl)
 	if err != nil {
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	if err = cdc.Unmarshal(C.GoBytes(unsafe.Pointer(serializedProto.data), C.int(serializedProto.data_length)), msg); err != nil {
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	eitherAsyncErr := txClient.SignAndBroadcast(goCtx, msg)
 	err, errCh := eitherAsyncErr.SyncOrAsyncError()
 	if err != nil {
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	go func() {
@@ -130,7 +130,7 @@ func TxClient_SignAndBroadcastMany(
 	if err != nil {
 		err = fmt.Errorf("getting tx client ref: %s", err)
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	if protoMessageArray.num_messages == 0 {
@@ -142,14 +142,14 @@ func TxClient_SignAndBroadcastMany(
 	if err != nil {
 		err = fmt.Errorf("converting C proto messages to Go: %s", err)
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	eitherAsyncErr := txClient.SignAndBroadcast(goCtx, msgs...)
 	err, errCh := eitherAsyncErr.SyncOrAsyncError()
 	if err != nil {
 		C.bridge_error(op, C.CString(err.Error()))
-		return C.go_ref(ZeroGoRef)
+		return C.go_ref(NilGoRef)
 	}
 
 	go func() {

--- a/cgo/tx_context.go
+++ b/cgo/tx_context.go
@@ -102,7 +102,7 @@ func NewTxContext(tcpURL *C.char, cErr **C.char) C.go_ref {
 		return 0
 	}
 
-	return C.go_ref(SetGoMem(txCtx))
+	return SetGoMem(txCtx)
 }
 
 // TODO_IN_THIS_COMMIT: godoc...


### PR DESCRIPTION
### Changes

- push `GoRef` and `C.go_ref` type casting down into `GetGoMem` and `SetGoMem`.
- add godoc comments
- consolidate NilGoRef and ZeroGoRef
- add a mutex to protect the memory map
- convert the ref counter to an atomic